### PR TITLE
Added information on potential error that could occur during vcs-import step of installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ vcs-import < mh_autotune/dependencies.yaml
 ```
 catkin build
 ```
+
+***Note 3, you could get build errors such as : "set GLOG_INCLUDE_DIR to directory containing glog/logging.h" for example from building [rotors_simulator](https://github.com/ethz-asl/rotors_simulator) module, which is used inside this project. These errors occur because ros package dependencies for each modules are not installed yet. To do this, visit [here](http://wiki.ros.org/rosdep), or just simply type `rosdep install --from-paths src --ignore-src -r -y` command at the `~/autotune_ws` directory***
+
+***Note 4, you could get build errors like "Could not find a package configuration file provided by "gazebo_plugins"". This can occur for example if you only have installed 'ros-YOUR_DISTRO_NAME-desktop' through apt package manager, and not 'ros-YOUR_DISTRO_NAME-desktop-full' (which includes the gazebo interface & gazebo itself!). So you could try `sudo apt install ros-YOUR_DISTRO_NAME-desktop-full` to avoid this issue***                                       
+                                          
+                                          
 6. Add sourcing of your catkin workspace and AUTOTUNE_PATH environment variable to your ```.bashrc``` file:
 ```
 echo "source ~/autotune_ws/devel/setup.bash" >> ~/.bashrc

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ git clone https://github.com/uzh-rpg/mh_autotune.git
 ```
 vcs-import < mh_autotune/dependencies.yaml
 ```
+***Note 1, if you get error like 'vcs-import: command not found', you need to install the vcstool. For help, visit [here](http://wiki.ros.org/vcstool)***
+
+***Note 2, if you get error like 'Could not determine ref type of version: git@github.com: Permission denied (publickey)', visit [this page](https://docs.github.com/en/github/authenticating-to-github/troubleshooting-ssh/error-permission-denied-publickey) to resolve the issue. You could [add a SSH key](https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) and connect it to your Github account for example to solve this error***                                         
+                                          
 4. Download the Flightmare Unity Binary RPG_Flightmare.tar.xz for rendering from the [Releases](https://github.com/uzh-rpg/flightmare/releases) and extract it into ```~/autotune_ws/src/flightmare/flightrender```.
 
 5. Build:


### PR DESCRIPTION
I encountered 2 errors while setting up, thought it would help others if this info was added on README!

1. First error happens when vcs tool isn't installed
2. Second one occurs when github SSH isn't added
3. Third occurs when you don't install the ros package dependencies
4. Fourth one is when you don't have gazebo stuff already installed

Example of the second error :

![image](https://user-images.githubusercontent.com/23277211/126680007-af7ed6b6-6287-45e6-bdab-5dbcb58ad436.png)