### PR TITLE
Fix autotune.py typo and add package python library dependencies

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,9 @@
   <depend>flightlib</depend>
   <depend>roscpp</depend>
   <depend>rospy</depend>
+  <depend>pandas</depend>
+  <depend>numpy</depend>
+  <depend>scikit</depend>
   <depend>tf</depend>
   <depend>autopilot</depend>
   <depend>quadrotor_common</depend>

--- a/src/regressor.py
+++ b/src/regressor.py
@@ -62,7 +62,7 @@ def train(level, resources_path, feature_list):
       for _, p in df.iterrows():
         q = np.array([p.loc["q_w"], p.loc["q_x"], p.loc["q_y"], p.loc["q_z"]])
         u_sum = p.loc["u_1"] + p.loc["u_2"] + p.loc["u_3"] + p.loc["u_4"]
-        acc = minimum_time_trajectory_parser.rotateVectorByQuat(u_sum, q)
+        acc = planner.rotateVectorByQuat(u_sum, q)
         accelerations["f_x"].append(acc[0][0])
         accelerations["f_y"].append(acc[1][0])
         accelerations["f_z"].append(acc[2][0]-9.8066)
@@ -142,7 +142,7 @@ def infer(models, scalers, file_name, resources_path, feature_list):
   for _, p in df.iterrows():
     q = np.array([p.loc["q_w"], p.loc["q_x"], p.loc["q_y"], p.loc["q_z"]])
     u_sum = p.loc["u_1"] + p.loc["u_2"] + p.loc["u_3"] + p.loc["u_4"]
-    acc = minimum_time_trajectory_parser.rotateVectorByQuat(u_sum, q)
+    acc = planner.rotateVectorByQuat(u_sum, q)
     accelerations["f_x"].append(acc[0][0])
     accelerations["f_y"].append(acc[1][0])
     accelerations["f_z"].append(acc[2][0]-9.8066)


### PR DESCRIPTION
As mentioned in #1, the autotune.py file wasn't working properly.

Which was because of :
1. Lack of python library (so I added the dependency in package.xml)
2. Typo in the file itself (which was mentioned here, and was supposed to be fixed : https://www.gitmemory.com/issue/uzh-rpg/mh_autotune/3/824820238)

Now, the quadcopter is correctly going around in circles!! Weeeyyy

![image](https://user-images.githubusercontent.com/23277211/126797991-44232bef-2641-4fb3-9b90-2e478db6ce43.png)
